### PR TITLE
[ fix bug] superagent post请求异常 Z_DATA_ERROR

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -240,6 +240,7 @@ class Pay {
         'Content-Type': 'application/json',
         'User-Agent': this.userAgent,
         Authorization: authorization,
+         'Accept-Encoding': 'gzip',
       });
       return {
         status: result.status,


### PR DESCRIPTION
刚开始出现了Cannot read property 'text' of null\n，追进去打印一下发现catched 的 error 是这样的，{code:Z_DATA_ERROR,errno:-3,response:null}}，在研究发现是 superagent post请求incorrect header check at Unzip.zlibOnError Z_DATA_ERROR 参考https://github.com/visionmedia/superagent/issues/927  添加了 'Accept-Encoding': 'gzip'，支付下单成功。

我不太理解为什么前几天没有出这个问题，今儿就Z_DATA_ERROR 了，相关代码没有变动啊。