### PR TITLE
修复APP调起支付时出现“支付验证签名失败“的问题

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -394,7 +394,7 @@ class Pay {
         prepayid: result.prepay_id,
         sign: '',
       };
-      const str = [data.appid, data.timestamp, data.noncestr, data.package, ''].join('\n');
+      const str = [data.appid, data.timestamp, data.noncestr, data.prepayid, ''].join('\n');
       data.sign = this.sign(str);
       return data;
     }


### PR DESCRIPTION
APP调起支付  签名，使用字段appId、timeStamp、nonceStr、prepayid计算得出的签名值
https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_2_4.shtml