### PR TITLE
添加微信支付公钥验签

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ import WxPay from 'wechatpay-node-v3'; // 支持使用require
 import fs from 'fs';
 import request from 'superagent';
 
+
+
 const pay = new WxPay({
   appid: '直连商户申请的公众号或移动应用appid',
   mchid: '商户号',

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ const pay = new WxPay({
   mchid: '商户号',
   publicKey: fs.readFileSync('./apiclient_cert.pem'), // 公钥
   privateKey: fs.readFileSync('./apiclient_key.pem'), // 秘钥
+  wxPayPublicKey: fs.readFileSync('./pub_key.pem'), // 微信支付公钥证书
+  wxPayPublicId： 'PUB_KEY_ID_0000000000000024101100397200000006', // 微信支付公钥证书id
 });
 
 # 这里以h5支付为例
@@ -112,6 +114,8 @@ pay.createHttp(...);
 |authType|认证类型，目前为WECHATPAY2-SHA256-RSA2048|否|
 |userAgent|自定义User-Agent|否|
 |key|APIv3密钥|否 有验证回调必须|
+|wxPayPublicKey|微信支付公钥证书|否 新注册商户或平台证书切换微信支付公钥必填|
+|wxPayPublicId|微信支付公钥证书id|否 新注册商户或平台证书切换微信支付公钥必填|
 
 ## 注意
 1. serial_no是证书序列号 请在命令窗口使用 `openssl x509 -in apiclient_cert.pem -noout -serial` 获取
@@ -179,6 +183,7 @@ pay.createHttp(...);
 |v2.1.8|修复回调签名key错误|
 |v2.2.0|修复回调解密报Unsupported state or unable to authenticate data |
 |v2.2.1|上传图片 |
+|v2.2.2|增加微信支付公钥回调签名验证|
 
 ## 文档
 [v2支付文档](https://pay.weixin.qq.com/wiki/doc/api/index.html)

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ import {
   ICertificates,
 } from './lib/interface';
 import { IcombineH5, IcombineNative, IcombineApp, IcombineJsapi, IcloseSubOrders } from './lib/combine_interface';
-import { BatchesTransfer, FindRefunds, ProfitSharing, Refunds, UploadImages } from './lib/interface-v2';
+import { BatchesTransfer, FindRefunds, ProfitSharing, Refunds } from './lib/interface-v2';
 import { Base } from './lib/base';
 import { IPayRequest } from './lib/pay-request.interface';
 import { PayRequest } from './lib/pay-request';
@@ -34,20 +34,23 @@ class Pay extends Base {
 
   protected key?: string; // APIv3密钥
   protected static certificates: { [key in string]: string } = {}; // 微信平台证书 key 是 serialNo, value 是 publicKey
+  protected wxPayPublicKey? :Buffer; // 支付平台公钥
+  protected wxPayPublicId? :string; // 支付平台密钥
+
   /**
    * 构造器
    * @param appid 直连商户申请的公众号或移动应用appid。
    * @param mchid 商户号
    * @param publicKey 公钥
    * @param privateKey 密钥
-   * @param options 可选参数 object 包括下面参数
+   * @param optipns 可选参数 object 包括下面参数
    *
    * @param serial_no  证书序列号
    * @param authType 可选参数 认证类型，目前为WECHATPAY2-SHA256-RSA2048
    * @param userAgent 可选参数 User-Agent
    * @param key 可选参数 APIv3密钥
    */
-  public constructor(appid: string, mchid: string, publicKey: Buffer, privateKey: Buffer, options?: Ioptions);
+  public constructor(appid: string, mchid: string, publicKey: Buffer, privateKey: Buffer, optipns?: Ioptions);
   /**
    * 构造器
    * @param obj object类型 包括下面参数
@@ -62,7 +65,7 @@ class Pay extends Base {
    * @param key 可选参数 APIv3密钥
    */
   public constructor(obj: Ipay);
-  public constructor(arg1: Ipay | string, mchid?: string, publicKey?: Buffer, privateKey?: Buffer, options?: Ioptions) {
+  public constructor(arg1: Ipay | string, mchid?: string, publicKey?: Buffer, privateKey?: Buffer, optipns?: Ioptions) {
     super();
 
     if (arg1 instanceof Object) {
@@ -77,12 +80,23 @@ class Pay extends Base {
       this.authType = arg1.authType || 'WECHATPAY2-SHA256-RSA2048';
       this.userAgent = arg1.userAgent || '127.0.0.1';
       this.key = arg1.key;
+
+      if (arg1.wxPayPublicKey) {
+        this.wxPayPublicKey = arg1.wxPayPublicKey;
+      }
+      if (arg1.wxPayPublicId) {
+        this.wxPayPublicId = arg1.wxPayPublicId;
+      }
+
+
     } else {
-      const _optipns = options || {};
+      const _optipns = optipns || {};
       this.appid = arg1;
       this.mchid = mchid || '';
       this.publicKey = publicKey;
       this.privateKey = privateKey;
+      this.wxPayPublicKey = _optipns.wxPayPublicKey;
+      this.wxPayPublicId = _optipns.wxPayPublicId;
 
       this.authType = _optipns.authType || 'WECHATPAY2-SHA256-RSA2048';
       this.userAgent = _optipns.userAgent || '127.0.0.1';
@@ -107,7 +121,7 @@ class Pay extends Base {
    */
   public async get_certificates(apiSecret: string): Promise<ICertificates[]> {
     const url = 'https://api.mch.weixin.qq.com/v3/certificates';
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
 
     const result = await this.httpService.get(url, headers);
@@ -137,7 +151,7 @@ class Pay extends Base {
    */
   private async fetchCertificates(apiSecret?: string) {
     const url = 'https://api.mch.weixin.qq.com/v3/certificates';
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
     const result = await this.httpService.get(url, headers);
 
@@ -194,6 +208,23 @@ class Pay extends Base {
   }) {
     const { timestamp, nonce, body, serial, signature, apiSecret } = params;
 
+
+    const serial_on = serial.startsWith('PUB_KEY_ID_');
+
+    const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
+    const data = `${timestamp}\n${nonce}\n${bodyStr}\n`;
+    const verify = crypto.createVerify('RSA-SHA256');
+
+
+    if (serial_on) {
+      if(!this.wxPayPublicKey) {
+        throw new Error('缺少微信支付公钥');
+      }
+      verify.update(data);
+      return verify.verify(this.wxPayPublicKey, signature, 'base64');
+    }
+
+
     let publicKey = Pay.certificates[serial];
 
     if (!publicKey) {
@@ -206,9 +237,8 @@ class Pay extends Base {
       throw new Error('平台证书序列号不相符，未找到平台序列号');
     }
 
-    const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
-    const data = `${timestamp}\n${nonce}\n${bodyStr}\n`;
-    const verify = crypto.createVerify('RSA-SHA256');
+    
+    
     verify.update(data);
 
     return verify.verify(publicKey, signature, 'base64');
@@ -328,6 +358,7 @@ class Pay extends Base {
     decipher.setAuthTag(authTag);
     decipher.setAAD(Buffer.from(associated_data));
     const decoded = decipher.update(data, undefined, 'utf8');
+    decipher.final();
 
     try {
       return JSON.parse(decoded);
@@ -338,7 +369,7 @@ class Pay extends Base {
   /**
    * 参数初始化
    */
-  protected buildAuthorization(method: string, url: string, params?: Record<string, any>) {
+  protected init(method: string, url: string, params?: Record<string, any>) {
     const nonce_str = Math.random()
         .toString(36)
         .substr(2, 15),
@@ -362,8 +393,8 @@ class Pay extends Base {
     };
     const url = 'https://api.mch.weixin.qq.com/v3/pay/transactions/h5';
 
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json', 'Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -379,7 +410,7 @@ class Pay extends Base {
     };
     const url = 'https://api.mch.weixin.qq.com/v3/combine-transactions/h5';
 
-    const authorization = this.buildAuthorization('POST', url, _params);
+    const authorization = this.init('POST', url, _params);
 
     const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
 
@@ -398,8 +429,8 @@ class Pay extends Base {
     };
     const url = 'https://api.mch.weixin.qq.com/v3/pay/transactions/native';
 
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -415,8 +446,8 @@ class Pay extends Base {
     };
     const url = 'https://api.mch.weixin.qq.com/v3/combine-transactions/native';
 
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -432,8 +463,8 @@ class Pay extends Base {
     };
     const url = 'https://api.mch.weixin.qq.com/v3/pay/transactions/app';
 
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     const result = await this.httpService.post(url, _params, headers);
     if (result.status === 200 && result.data.prepay_id) {
       const data = {
@@ -466,8 +497,8 @@ class Pay extends Base {
     };
     const url = 'https://api.mch.weixin.qq.com/v3/combine-transactions/app';
 
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     const result = await this.httpService.post(url, _params, headers);
     if (result.status === 200 && result.data.prepay_id) {
       const data = {
@@ -500,9 +531,10 @@ class Pay extends Base {
     };
     const url = 'https://api.mch.weixin.qq.com/v3/pay/transactions/jsapi';
 
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     const result = await this.httpService.post(url, _params, headers);
+    
     if (result.status === 200 && result.data.prepay_id) {
       const data = {
         appId: _params.appid,
@@ -533,8 +565,8 @@ class Pay extends Base {
     };
     const url = 'https://api.mch.weixin.qq.com/v3/combine-transactions/jsapi';
 
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     const result = await this.httpService.post(url, _params, headers);
     if (result.status === 200 && result.data.prepay_id) {
       const data = {
@@ -567,7 +599,7 @@ class Pay extends Base {
       throw new Error('缺少transaction_id或者out_trade_no');
     }
 
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -579,7 +611,7 @@ class Pay extends Base {
     if (!combine_out_trade_no) throw new Error('缺少combine_out_trade_no');
     const url = `https://api.mch.weixin.qq.com/v3/combine-transactions/out-trade-no/${combine_out_trade_no}`;
 
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -595,8 +627,8 @@ class Pay extends Base {
       mchid: this.mchid,
     };
     const url = `https://api.mch.weixin.qq.com/v3/pay/transactions/out-trade-no/${out_trade_no}/close`;
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -613,8 +645,8 @@ class Pay extends Base {
       sub_orders,
     };
     const url = `https://api.mch.weixin.qq.com/v3/combine-transactions/out-trade-no/${combine_out_trade_no}/close`;
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -636,7 +668,7 @@ class Pay extends Base {
       })
       .join('&');
     url = url + `?${querystring}`;
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -659,7 +691,7 @@ class Pay extends Base {
       })
       .join('&');
     url = url + `?${querystring}`;
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -668,7 +700,7 @@ class Pay extends Base {
    * @param download_url 请求参数 路径 参数介绍 请看文档https://pay.weixin.qq.com/wiki/doc/apiv3/apis/chapter3_1_8.shtml
    */
   public async downloadBill(download_url: string) {
-    const authorization = this.buildAuthorization('GET', download_url);
+    const authorization = this.init('GET', download_url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(download_url, headers);
   }
@@ -683,8 +715,8 @@ class Pay extends Base {
       ...params,
     };
 
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -695,7 +727,7 @@ class Pay extends Base {
     if (!out_refund_no) throw new Error('缺少out_refund_no');
     const url = `https://api.mch.weixin.qq.com/v3/refund/domestic/refunds/${out_refund_no}`;
 
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -715,9 +747,9 @@ class Pay extends Base {
 
     const serial_no = _params?.wx_serial_no;
     delete _params.wx_serial_no;
-    const authorization = this.buildAuthorization('POST', url, _params);
+    const authorization = this.init('POST', url, _params);
 
-    const headers = this.getHeaders(authorization, { 'Wechatpay-Serial': serial_no || this.serial_no, 'Content-Type': 'application/json' });
+    const headers = this.wxPayPublicId ? this.getHeaders(authorization, { 'Wechatpay-Serial': serial_no || this.wxPayPublicId, 'Content-Type': 'application/json' }) :  this.getHeaders(authorization, { 'Wechatpay-Serial': serial_no || this.serial_no, 'Content-Type': 'application/json' });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -729,7 +761,7 @@ class Pay extends Base {
   ): Promise<BatchesTransfer.QueryBatchesTransferByWx.IOutput> {
     const baseUrl = `https://api.mch.weixin.qq.com/v3/transfer/batches/batch-id/${params.batch_id}`;
     const url = baseUrl + this.objectToQueryString(params, ['batch_id']);
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -742,7 +774,7 @@ class Pay extends Base {
   ): Promise<BatchesTransfer.QueryBatchesTransferDetailByWx.IOutput> {
     const baseUrl = `https://api.mch.weixin.qq.com/v3/transfer/batches/batch-id/${params.batch_id}/details/detail-id/${params.detail_id}`;
     const url = baseUrl + this.objectToQueryString(params, ['batch_id', 'detail_id']);
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -755,7 +787,7 @@ class Pay extends Base {
   ): Promise<BatchesTransfer.QueryBatchesTransferList.IOutput> {
     const baseUrl = `https://api.mch.weixin.qq.com/v3/transfer/batches/out-batch-no/${params.out_batch_no}`;
     const url = baseUrl + this.objectToQueryString(params, ['out_batch_no']);
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -768,7 +800,7 @@ class Pay extends Base {
   ): Promise<BatchesTransfer.QueryBatchesTransferDetail.IOutput> {
     const baseUrl = `https://api.mch.weixin.qq.com/v3/transfer/batches/out-batch-no/${params.out_batch_no}/details/out-detail-no/${params.out_detail_no}`;
     const url = baseUrl + this.objectToQueryString(params, ['out_batch_no', 'out_detail_no']);
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -792,9 +824,9 @@ class Pay extends Base {
 
     const serial_no = _params?.wx_serial_no;
     delete _params.wx_serial_no;
-    const authorization = this.buildAuthorization('POST', url, _params);
+    const authorization = this.init('POST', url, _params);
 
-    const headers = this.getHeaders(authorization, { 'Wechatpay-Serial': serial_no || this.serial_no, 'Content-Type': 'application/json' });
+    const headers = this.wxPayPublicId ? this.getHeaders(authorization, { 'Wechatpay-Serial': serial_no || this.wxPayPublicId, 'Content-Type': 'application/json' }) :  this.getHeaders(authorization, { 'Wechatpay-Serial': serial_no || this.serial_no, 'Content-Type': 'application/json' });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -806,7 +838,7 @@ class Pay extends Base {
     if (!out_order_no) throw new Error('缺少out_order_no');
     let url = `https://api.mch.weixin.qq.com/v3/profitsharing/orders/${out_order_no}`;
     url = url + this.objectToQueryString({ transaction_id });
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -823,8 +855,8 @@ class Pay extends Base {
       ...params,
     };
 
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -839,7 +871,7 @@ class Pay extends Base {
     if (!out_order_no) throw new Error('缺少out_order_no');
     let url = `https://api.mch.weixin.qq.com/v3/profitsharing/return-orders/${out_return_no}`;
     url = url + this.objectToQueryString({ out_order_no });
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -856,8 +888,8 @@ class Pay extends Base {
       ...params,
     };
 
-    const authorization = this.buildAuthorization('POST', url, _params);
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const authorization = this.init('POST', url, _params);
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -867,7 +899,7 @@ class Pay extends Base {
   public async query_profitsharing_amounts(transaction_id: string): Promise<ProfitSharing.QueryProfitSharingAmounts.IOutput> {
     if (!transaction_id) throw new Error('缺少transaction_id');
     const url = `https://api.mch.weixin.qq.com/v3/profitsharing/transactions/${transaction_id}/amounts`;
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
@@ -887,9 +919,9 @@ class Pay extends Base {
 
     const serial_no = _params?.wx_serial_no;
     delete _params.wx_serial_no;
-    const authorization = this.buildAuthorization('POST', url, _params);
+    const authorization = this.init('POST', url, _params);
 
-    const headers = this.getHeaders(authorization, { 'Wechatpay-Serial': serial_no || this.serial_no, 'Content-Type': 'application/json' });
+    const headers = this.wxPayPublicId ? this.getHeaders(authorization, { 'Wechatpay-Serial': serial_no || this.wxPayPublicId, 'Content-Type': 'application/json' }) :  this.getHeaders(authorization, { 'Wechatpay-Serial': serial_no || this.serial_no, 'Content-Type': 'application/json' });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -906,9 +938,9 @@ class Pay extends Base {
       ...params,
     };
 
-    const authorization = this.buildAuthorization('POST', url, _params);
+    const authorization = this.init('POST', url, _params);
 
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
+    const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json','Wechatpay-Serial' : this.wxPayPublicId ? this.wxPayPublicId : null });
     return await this.httpService.post(url, _params, headers);
   }
   /**
@@ -919,35 +951,11 @@ class Pay extends Base {
     if (!bill_date) throw new Error('缺少bill_date');
     let url = `https://api.mch.weixin.qq.com/v3/profitsharing/bills`;
     url = url + this.objectToQueryString({ bill_date, ...(tar_type && { tar_type }) });
-    const authorization = this.buildAuthorization('GET', url);
+    const authorization = this.init('GET', url);
     const headers = this.getHeaders(authorization);
     return await this.httpService.get(url, headers);
   }
   //#endregion 分账
-  public async upload_images(pic_buffer: Buffer, filename: string): Promise<UploadImages.IOutput> {
-    //meta信息
-    const fileinfo = {
-      filename,
-      sha256: '',
-    };
-    const sign = crypto.createHash('sha256');
-    sign.update(pic_buffer);
-    fileinfo.sha256 = sign.digest('hex');
-
-    const url = '/v3/merchant/media/upload';
-
-    const authorization = this.buildAuthorization('POST', url, fileinfo);
-
-    const headers = this.getHeaders(authorization, { 'Content-Type': 'multipart/form-data;boundary=boundary' });
-    return await this.httpService.post(
-      url,
-      {
-        fileinfo,
-        pic_buffer,
-      },
-      headers,
-    );
-  }
 }
 
 export = Pay;

--- a/lib/interface.ts
+++ b/lib/interface.ts
@@ -55,6 +55,8 @@ export interface Ioptions {
   authType?: string;
   key?: string;
   serial_no?: string;
+  wxPayPublicKey?: Buffer; // 支付平台公钥
+  wxPayPublicId?: string; // 支付平台密钥
 }
 export interface Ipay {
   appid: string; //  直连商户申请的公众号或移动应用appid。
@@ -65,6 +67,8 @@ export interface Ipay {
   authType?: string; // 认证类型，目前为WECHATPAY2-SHA256-RSA2048
   userAgent?: string;
   key?: string;
+  wxPayPublicKey?: Buffer; // 支付平台公钥
+  wxPayPublicId?: string; // 支付平台密钥
 }
 export interface Ih5 {
   appid?: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechatpay-node-v3",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "微信支付文档v3",
   "keywords": [
     "node",


### PR DESCRIPTION
修改内容：
1.添加微信支付公钥证书和微信支付公钥ID的变量、接口，老商户号非必填（从平台证书切换微信支付公钥验签必填），新注册商户没有平台证书验签必填
2.微信支付公钥验签回调，根据Wechatpay-Serial的PUB_KEY_ID_微信支付公钥ID关键词判断使用平台证书或微信公钥证书进行验签。
3.所有发起支付、转账等请求头添加Wechatpay-Serial: 微信支付公钥ID，根据文档要求使用微信支付公钥部分字段加密必须携带，以及平台证书切换微信支付公钥验签过程中凡是使用支付相关接口必须携带（切换完成并废弃平台证书可不携带，但部分字段必须携带）。

已测试微信小程序支付，支付回调通知没问题，因为本人是个体户，而且只有小程序能测试，其它功能没办法测试，请各位大佬测试，若没问题请求合并。