### PR TITLE
升级依赖superagent到10.2.1（老版本提示安全漏洞）

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@fidm/x509": "1.2.1",
-    "superagent": "8.0.6"
+    "@fidm/x509": "^1.2.1",
+    "superagent": "^10.2.1"
   },
   "devDependencies": {
     "@nestjs/common": "8.2.4",


### PR DESCRIPTION
依赖superagent 8.0.6的依赖formidable存在安全漏洞，升级到最新版即可修复

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/1decd201-287e-4463-9d30-e8c7287ea2e5" />
