### PR TITLE
fix: default value of API v3 secret is missing

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -135,7 +135,7 @@ class Pay extends Base {
    * @param apiSecret APIv3密钥
    * https://pay.weixin.qq.com/wiki/doc/apiv3/apis/wechatpay5_1.shtml
    */
-  private async fetchCertificates(apiSecret?: string) {
+  private async fetchCertificates(apiSecret = this.key) {
     const url = 'https://api.mch.weixin.qq.com/v3/certificates';
     const authorization = this.buildAuthorization('GET', url);
     const headers = this.getHeaders(authorization, { 'Content-Type': 'application/json' });
@@ -192,7 +192,7 @@ class Pay extends Base {
     signature: string;
     apiSecret?: string;
   }) {
-    const { timestamp, nonce, body, serial, signature, apiSecret } = params;
+    const { timestamp, nonce, body, serial, signature, apiSecret = this.key } = params;
 
     let publicKey = Pay.certificates[serial];
 


### PR DESCRIPTION
@klover2 The document says [`apiSecret` parameter is optional for `verifySign()` method][1] if it has been passed in through `new WxPay()`, but the source code doesn't use `this.key` as its default value actually.

[1]: https://github.com/klover2/wechatpay-node-v3-ts/blob/master/docs/verifySign.md#%E7%AD%BE%E5%90%8D%E9%AA%8C%E8%AF%81